### PR TITLE
Rename HTTP metrics to conform to best practices

### DIFF
--- a/src/main/java/works/weave/socks/orders/middleware/HTTPMonitoringInterceptor.java
+++ b/src/main/java/works/weave/socks/orders/middleware/HTTPMonitoringInterceptor.java
@@ -20,9 +20,9 @@ import java.util.Set;
 
 public class HTTPMonitoringInterceptor implements HandlerInterceptor {
     static final Histogram requestLatency = Histogram.build()
-            .name("request_duration_seconds")
+            .name("http_request_duration_seconds")
             .help("Request duration in seconds.")
-            .labelNames("service", "method", "route", "status_code")
+            .labelNames("service", "method", "path", "status_code")
             .register();
 
     private static final String startTimeKey = "startTime";


### PR DESCRIPTION
It seems like http_request_duration_seconds is the expected metric name for http request durations.
This change is similar to https://github.com/microservices-demo/carts/commit/bd16e1e02aa005faf357902032c47bc66aed23df